### PR TITLE
remove an extra word

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -133,7 +133,7 @@ LNK_HOME=/tmp/link-local-1 ./lnk.sh profile peer
 
 [source,bash]
 ----
-LNK_HOME=/tmp/link-local-2 ./lnk.sh lnk clone \
+LNK_HOME=/tmp/link-local-2 ./lnk.sh clone \
     --urn <project URN>\
     --path theproject2\
     --peer <first peer ID>


### PR DESCRIPTION
There is an extra `lnk` that breaks the command.